### PR TITLE
Fix onYouTubeIframeAPIReady init

### DIFF
--- a/src/ytv.js
+++ b/src/ytv.js
@@ -139,6 +139,9 @@
                     var firstScriptTag = doc.getElementsByTagName('script')[0];
                     firstScriptTag.parentNode.insertBefore(tag, firstScriptTag);
                     win.onYouTubeIframeAPIReady = fn;
+                    if (win.onYouTubeIframeAPIReady) {
+						onYouTubeIframeAPIReady();
+					}
                 },
                 build: function(){
                     settings.element.className = "ytv-canvas";


### PR DESCRIPTION
Call onYouTubeIframeAPIReady() if it is already instanced.
Usefull in the single-page web application when you call this plugin more than once.