### PR TITLE
Added 'wmode' option, fixed a few IE bugs and added check for available video.stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ settings = {
     autoplay: false,
     chainVideos: true,
     browsePlaylists: false,
+    wmode: 'opaque',
     events: {
         videoReady: function(){},
         stateChange: function(){}
@@ -74,6 +75,7 @@ settings = {
 * `annotations`: (Boolean) If `false`, the annotations from the YouTube video will be hidden
 * `autoplay`: (Boolean) If `true`, the first video in the list will automatically play once the player has loaded
 * `chainVideos`: (Boolean) If `true`, the next video in que will automatically play after the current video has completed
+* `wmode`: (String) Sets the Window Mode property for transparency, layering, and positioning in the browser. Values can be: `window` - movie plays in its own rectangular window on a web page. `opaque` - the movie hides everything on the page behind it. `transparent` - the background of the HTML page shows through all transparent portions of the movie, this may slow animation performance.
 * `events`: The respective events will fire when key actions in the player have been called
 
 

--- a/src/ytv.js
+++ b/src/ytv.js
@@ -26,6 +26,7 @@
                 autoplay: false,
                 chainVideos: true,
                 browsePlaylists: false,
+                wmode: 'opaque',
                 events: {
                     videoReady: noop,
                     stateChange: noop
@@ -281,7 +282,7 @@
                                 showinfo: 0,
                                 iv_load_policy: settings.annotations ? '' : 3, 
                                 autoplay: autoplay ? 1 : 0,
-                                wmode: 'transparent' 
+                                wmode: settings.wmode
                             }
                         });
                         


### PR DESCRIPTION
The 'wmode' option was needed to fix an overlay bug happening on IE/Chrome.
The 'target.dataset' had to be changed with 'target.getAttribute('data-xxxxx')' as IE doesn't support datasets.
The check for the available video.stats was needed as some videos seem to hide that data causing the player to fail.
I also updated the readme.md file with the new option infos.
