### PR TITLE
Wrong url fix

### DIFF
--- a/src/ytv.js
+++ b/src/ytv.js
@@ -181,7 +181,7 @@
                             var list = '',
                                 user = {
                                     title: userInfo.entry.title.$t,
-                                    url: 'http://youtube.com/user/'+userInfo.entry.yt$username.display,
+                                    url: 'http://youtube.com/user/'+userInfo.entry.yt$username.$t,
                                     thumb: userInfo.entry.media$thumbnail.url,
                                     summary: userInfo.entry.summary.$t,
                                     subscribers: userInfo.entry.yt$statistics.subscriberCount,


### PR DESCRIPTION
According to YouTube Api documentation "for users who have accounts
that are connected to Google+, the (display) attribute value will be
the user's full public display name", not the YouTube username. This
causes wrong url links for Google+ users.

For example, using "TonightAliveBand" as user generates http://www.youtube.com/user/Tonight%20Alive insetad of http://www.youtube.com/user/tonightaliveband

This fix resolves the issue.
